### PR TITLE
set hostname to 0.0.0.0

### DIFF
--- a/examples/with-docker/Dockerfile
+++ b/examples/with-docker/Dockerfile
@@ -55,5 +55,7 @@ USER nextjs
 EXPOSE 3000
 
 ENV PORT 3000
+# set hostname to localhost
+ENV HOSTNAME "0.0.0.0"
 
 CMD ["node", "server.js"]


### PR DESCRIPTION
When I try to deploy to Google Cloud Run it fails after some investigation I saw this line in 

.next/standalone/server.js
```javascript
const hostname = process.env.HOSTNAME || 'localhost'
``` 
This some how make this log when i run docker 
```shell
- ready started server on 172.17.0.2:3000, url: http://172.17.0.2:3000
``` 
I don't know why it's logging this address even if the server running on localhost.

So this my fix
Set hostname to 0.0.0.0 to avoid deployment failing on Google cloud run.